### PR TITLE
chore(release): publish v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+# [1.0.0](https://github.com/hidoo/data-from/compare/v0.3.1...v1.0.0) (2024-03-21)
+
+
+### Bug Fixes
+
+* **deps:** update dependency glob to v7.1.7 ([4f62cfc](https://github.com/hidoo/data-from/commit/4f62cfcebb7fded920ab87494dab7a4ea22db5d3))
+* **deps:** update dependency handlebars to v4.7.8 ([255ba46](https://github.com/hidoo/data-from/commit/255ba46b8d4a527ce0466f18896a8b16c26faf2a))
+* **deps:** update dependency js-yaml to v4.1.0 ([06877d0](https://github.com/hidoo/data-from/commit/06877d07493ced5743b5456151d151b2ae5133ba))
+* **deps:** update dependency json5 to v2.2.1 ([a1ced46](https://github.com/hidoo/data-from/commit/a1ced46a1383de7aa023903bd8dca8aa118a0684))
+* **deps:** update dependency json5 to v2.2.2 [security] ([5ca1b06](https://github.com/hidoo/data-from/commit/5ca1b0613be5bbfda1da6105ffca97ed01eca162))
+* **deps:** update dependency json5 to v2.2.3 ([1f27c7e](https://github.com/hidoo/data-from/commit/1f27c7e9e6dca3ad22bc7402651296fe41956bef))
+* **node:** remove node v10 support ([9eda732](https://github.com/hidoo/data-from/commit/9eda73269ab88d36d7e1a140c0bb295ca5d47cbd))
+
+
+* fix!: migrate to es modules ([8e1f004](https://github.com/hidoo/data-from/commit/8e1f004682e6bc36a13ce8fc99f7d2444ec40849))
+* fix!: update supported nodejs versions ([e49d540](https://github.com/hidoo/data-from/commit/e49d5406f47aaf413ed7ab835369f4f0df9ed953))
+
+
+### BREAKING CHANGES
+
+* Requires ES Modules.
+* Drop Node.js 12, 14, 16 support
+
+
+
 ## [0.3.1](https://github.com/hidoo/data-from/compare/v0.3.0...v0.3.1) (2021-03-29)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hidoo/data-from",
-  "version": "0.3.1",
+  "version": "1.0.0",
   "description": "Utility to get data from JSON, JSON5, and YAML.",
   "packageManager": "pnpm@8.15.5",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -58,8 +58,5 @@
     "js-yaml": "4.1.0",
     "json5": "2.2.3",
     "lodash.merge": "4.6.2"
-  },
-  "resolutions": {
-    "minimist": "^1.2.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  minimist: ^1.2.5
-
 dependencies:
   front-matter:
     specifier: 4.0.2
@@ -87,7 +84,7 @@ packages:
     resolution: {integrity: sha512-/AtaeEhT6ErpDhInbXmjHcUQXH0L0TEgscfcxk1qbOvLuKCa5aZT0SOOtDKFY96/CLROwbLSKyFor6idgNaU4Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.14.5
+      '@babel/code-frame': 7.24.2
       '@babel/generator': 7.14.8
       '@babel/helper-compilation-targets': 7.14.5(@babel/core@7.14.8)
       '@babel/helper-module-transforms': 7.14.8
@@ -187,7 +184,7 @@ packages:
       '@babel/helper-replace-supers': 7.14.5
       '@babel/helper-simple-access': 7.14.8
       '@babel/helper-split-export-declaration': 7.14.5
-      '@babel/helper-validator-identifier': 7.14.9
+      '@babel/helper-validator-identifier': 7.22.20
       '@babel/template': 7.14.5
       '@babel/traverse': 7.14.8
       '@babel/types': 7.14.9
@@ -285,7 +282,7 @@ packages:
     resolution: {integrity: sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.14.5
+      '@babel/code-frame': 7.24.2
       '@babel/parser': 7.14.8
       '@babel/types': 7.14.9
     dev: true
@@ -294,7 +291,7 @@ packages:
     resolution: {integrity: sha512-kexHhzCljJcFNn1KYAQ6A5wxMRzq9ebYpEDV4+WdNyr3i7O44tanbDOR/xjiG2F3sllan+LgwK+7OMk0EmydHg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.14.5
+      '@babel/code-frame': 7.24.2
       '@babel/generator': 7.14.8
       '@babel/helper-function-name': 7.14.5
       '@babel/helper-hoist-variables': 7.14.5
@@ -311,7 +308,7 @@ packages:
     resolution: {integrity: sha512-u0bLTnv3DFHeaQLYzb7oRJ1JHr1sv/SYDM7JSqHFFLwXG1wTZRughxFI5NCP8qBEo1rVVsn7Yg2Lvw49nne/Ow==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-validator-identifier': 7.14.9
+      '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
     dev: true
 
@@ -582,7 +579,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       string-width: 5.1.2
-      string-width-cjs: /string-width@4.2.0
+      string-width-cjs: /string-width@4.2.3
       strip-ansi: 7.1.0
       strip-ansi-cjs: /strip-ansi@6.0.1
       wrap-ansi: 8.1.0
@@ -3559,7 +3556,6 @@ packages:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
-    dev: true
 
   /string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}


### PR DESCRIPTION
### BREAKING CHANGE

+ Drop Node.js 12, 14, 16 support
+ Requires ES Modules
+ Changes `fromFiles` to async function
(You can use `fromFilesSync` instead if you need to use the synchronous function.)

